### PR TITLE
Rematch and menu

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -294,6 +294,11 @@ io.on('connection', socket => {
   socket.on('last-match', (playerOne, playerTwo, cb) => {
     c.lastMatch(db, playerOne, playerTwo).then(cb)
   })
+
+  socket.on('set-menu-state', state => io.emit('set-menu-state', state))
+  socket.on('menu-up', () => io.emit('menu-up'))
+  socket.on('menu-down', () => io.emit('menu-down'))
+  socket.on('menu-select', () => io.emit('menu-select'))
 })
 
 io.listen(config.port)

--- a/gpio/index.js
+++ b/gpio/index.js
@@ -11,6 +11,10 @@ const gpioReverse = {
   [config.playerTwo.red]: 'player two red'
 }
 
+const state = {
+  menu: false
+}
+
 function onPush (err, value, self, press, hold) {
   console.log(self.name, value)
 
@@ -52,9 +56,17 @@ function button (gpio, press, hold) {
     })
 }
 
-const emit = event => () => socket.emit(event)
+const emit = (event, menuEvent) => () => {
+  if (state.menu && menuEvent) socket.emit(menuEvent)
+  else socket.emit(event)
+}
 
-button(config.playerOne.green, emit('increment-player-one'))
-button(config.playerOne.red, emit('decrement-player-one'), emit('end-game'))
-button(config.playerTwo.green, emit('increment-player-two'))
-button(config.playerTwo.red, emit('decrement-player-two'), emit('end-game'))
+function toggleMenu () {
+  state.menu = !state.menu
+  socket.emit('set-menu-state', state.menu)
+}
+
+button(config.playerOne.green, emit('increment-player-one', 'menu-up'), toggleMenu)
+button(config.playerOne.red, emit('decrement-player-one', 'menu-down'), emit('end-game', 'menu-select'))
+button(config.playerTwo.green, emit('increment-player-two', 'menu-up'), toggleMenu)
+button(config.playerTwo.red, emit('decrement-player-two', 'menu-down'), emit('end-game', 'menu-select'))

--- a/web/css/main.css
+++ b/web/css/main.css
@@ -563,7 +563,7 @@ header .bg {
   padding: 0 1em;
 }
 
-#overlay {
+#overlay, #menu-overlay {
   display: none;
   position: fixed;
   top: 0;
@@ -574,9 +574,27 @@ header .bg {
   color: white;
   align-items: center;
   justify-content: center;
+  z-index: 2;
 }
 
 #overlay-content {
   border: 3px solid white;
   padding: .5em 1em;
+}
+
+#menu-overlay ul {
+  list-style-type: none;
+  padding: 0;
+}
+
+#menu-overlay li a {
+  display: block;
+  padding: .5em 1em;
+  background: #88e2f2;
+  color: white;
+  text-decoration: none;
+}
+
+#menu-overlay li a:focus {
+  background: #ff9e9e;
 }

--- a/web/index.html
+++ b/web/index.html
@@ -174,6 +174,13 @@
       <div id="overlay-content"></div>
     </div>
 
+    <div id="menu-overlay">
+      <ul>
+        <li><a href="#" data-event="rematch">Rematch (ranked)</a></li>
+        <li><a href="#" data-event="rematch-unranked">Rematch (for fun)</a></li>
+      </ul>
+    </div>
+
     <script src="js/bundle.js"></script>
   </body>
 </html>

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -2,6 +2,7 @@ const api = require('./api')
 const leaderboard = require('./leaderboard')
 const scoreboard = require('./scoreboard')
 const winner = require('./winner')
+const menu = require('./menu')
 
 leaderboard.render()
 
@@ -67,6 +68,11 @@ api.on('cancel', data => {
     showLeaderboard()
   }
 })
+
+api.on('set-menu-state', menu.render)
+api.on('menu-up', menu.up)
+api.on('menu-down', menu.down)
+api.on('menu-select', () => menu.select(api))
 
 api.emit('state', state => {
   if (state.match) {

--- a/web/js/menu.js
+++ b/web/js/menu.js
@@ -1,0 +1,34 @@
+const items = Array.from(document.querySelectorAll('#menu-overlay ul li a'))
+
+items.forEach(item => item.addEventListener('click', e => e.preventDefault()))
+
+let index = 0;
+
+exports.render = state => {
+  if (!state) {
+    document.querySelector('#menu-overlay').style.display = 'none'
+    return
+  }
+
+  document.querySelector('#menu-overlay').style.display = 'flex'
+}
+
+exports.up = () => {
+  index = index - 1
+  if (index < 0) index = items.length - 1
+
+  console.log('up', items, index)
+  items[index].focus()
+}
+
+exports.down = () => {
+  index = index + 1
+  if (index >= items.length - 1) index = 0
+
+  console.log('down', items, index)
+  items[index].focus()
+}
+
+exports.select = api => {
+  api.emit(items[index].datalist.event)
+}

--- a/web/js/menu.js
+++ b/web/js/menu.js
@@ -16,19 +16,15 @@ exports.render = state => {
 exports.up = () => {
   index = index - 1
   if (index < 0) index = items.length - 1
-
-  console.log('up', items, index)
   items[index].focus()
 }
 
 exports.down = () => {
   index = index + 1
   if (index >= items.length - 1) index = 0
-
-  console.log('down', items, index)
   items[index].focus()
 }
 
 exports.select = api => {
-  api.emit(items[index].datalist.event)
+  api.emit(items[index].dataset.event)
 }


### PR DESCRIPTION
Add a menu that allows to rematch (ranked or not) the current game (or last game if no game is on).

Only issue is that the rematch is not displayed on Flowdock, so we can't cancel it via the chat nor view the progress and end score.

Fixes https://github.com/busbud/pongdome/issues/24.