### PR TITLE
Change the way challenge ID is generated

### DIFF
--- a/chat/src/actions/challenge.js
+++ b/chat/src/actions/challenge.js
@@ -1,9 +1,4 @@
-const uuid = require('uuid')
-
-const getMatchId = message =>
-  message.thread || uuid.v4()
-
-module.exports = function challenge ({ bot, addRequest, matches, message, flags }) {
+module.exports = function challenge ({ bot, addRequest, message, flags }) {
   const challenger = message.author
   const mentions = bot.mentions(message)
 
@@ -11,9 +6,6 @@ module.exports = function challenge ({ bot, addRequest, matches, message, flags 
   if (mentions.length > 1) return message.send('Cannot challenge multiple people.')
 
   const challengee = mentions[0]
-  const id = getMatchId(message)
 
-  if (matches[id]) return message.send('There\'s already a challenge here.')
-
-  addRequest({ id, challenger, challengee, message, unranked: flags.forfun })
+  addRequest({ challenger, challengee, message, unranked: flags.forfun })
 }

--- a/chat/src/actions/forcechallenge.js
+++ b/chat/src/actions/forcechallenge.js
@@ -1,10 +1,4 @@
-const uuid = require('uuid')
-const config = require('../../config')
-
-const getMatchId = message =>
-  message.thread || uuid.v4()
-
-module.exports = function forcechallenge ({ bot, socket, saveState, addRequest, matches, message, flags, isAdmin }) {
+module.exports = function forcechallenge ({ bot, socket, saveState, addRequest, message, flags, isAdmin }) {
   if (!isAdmin) return message.send('Nope.')
 
   const mentions = bot.mentions(message)
@@ -14,11 +8,8 @@ module.exports = function forcechallenge ({ bot, socket, saveState, addRequest, 
 
   const challenger = mentions.length === 1 ? message.author : mentions.shift()
   const challengee = mentions.shift()
-  const id = getMatchId(message)
 
-  if (matches[id]) return message.send('There\'s already a challenge here.')
-
-  addRequest({ id, challenger, challengee, message, accepted: true, forced: true, unranked: flags.forfun })
+  const { id } = addRequest({ challenger, challengee, message, accepted: true, forced: true, unranked: flags.forfun })
 
   saveState()
 

--- a/chat/src/actions/openchallenge.js
+++ b/chat/src/actions/openchallenge.js
@@ -1,17 +1,8 @@
-const uuid = require('uuid')
-
-const getMatchId = message =>
-  message.thread || uuid.v4()
-
-module.exports = function openchallenge ({ bot, addRequest, matches, message, flags }) {
+module.exports = function openchallenge ({ bot, addRequest, message, flags }) {
   const challenger = message.author
   const mentions = bot.mentions(message)
 
   if (mentions.length) return message.send('It\'s an open challenge man...')
 
-  const id = getMatchId(message)
-
-  if (matches[id]) return message.send('There\'s already a challenge here.')
-
-  addRequest({ id, challenger, challengee: null, message, unranked: flags.forfun })
+  addRequest({ challenger, challengee: null, message, unranked: flags.forfun })
 }


### PR DESCRIPTION
Fixes https://github.com/busbud/pongdome/issues/42.

We now always generate a UUID for game ID, and keep track of thread ID in memory to avoid same thread games.

This prevents insert conflicts if a challenge is made in the same thread as another game that was already saved.

Also factors out the code to check if a challenge is made in the same thread as an existing unaccepted challenge or unfinished game, code is simpler and cleaner.