### PR TITLE
Improve tags and mentions parsing

### DIFF
--- a/chat/src/actions/challenge.js
+++ b/chat/src/actions/challenge.js
@@ -1,6 +1,6 @@
 module.exports = function challenge ({ bot, addRequest, message, flags }) {
   const challenger = message.author
-  const mentions = bot.mentions(message)
+  const mentions = message.mentions()
 
   if (!mentions.length) return message.send('Could not find who to challenge.')
   if (mentions.length > 1) return message.send('Cannot challenge multiple people.')

--- a/chat/src/actions/forcechallenge.js
+++ b/chat/src/actions/forcechallenge.js
@@ -1,7 +1,7 @@
 module.exports = function forcechallenge ({ bot, socket, saveState, addRequest, message, flags, isAdmin }) {
   if (!isAdmin) return message.send('Nope.')
 
-  const mentions = bot.mentions(message)
+  const mentions = message.mentions()
 
   if (!mentions.length) return message.send('Could not find who to challenge.')
   if (mentions.length > 2) return message.send('Too much people.')

--- a/chat/src/actions/h2h.js
+++ b/chat/src/actions/h2h.js
@@ -1,5 +1,5 @@
 module.exports = function streak ({ bot, socket, message }) {
-  const players = bot.mentions(message)
+  const players = message.mentions()
   if (players.length < 2) players.push(message.author)
   if (players.length < 2) return message.send('Need two users')
 

--- a/chat/src/actions/openchallenge.js
+++ b/chat/src/actions/openchallenge.js
@@ -1,6 +1,6 @@
 module.exports = function openchallenge ({ bot, addRequest, message, flags }) {
   const challenger = message.author
-  const mentions = bot.mentions(message)
+  const mentions = message.mentions()
 
   if (mentions.length) return message.send('It\'s an open challenge man...')
 

--- a/chat/src/actions/streak.js
+++ b/chat/src/actions/streak.js
@@ -24,7 +24,7 @@ ${list}`
 }
 
 module.exports = function streak ({ bot, socket, message }) {
-  const players = bot.mentions(message)
+  const players = message.mentions()
   if (!players.length) players.push(message.author)
   const playerOne = players[0]
   const playerTwo = players[1]


### PR DESCRIPTION
With Flowdock, fixes a bunch of bugs or usability issues due to the way we parse tags and users mentions.

Since tags and mentions are not supported in a private conversation, we try to match them directly in the text string.

This was already the case for tags in general but now we can use commands that require to mention users also in a private chat (without actually sending a notification to the the given users).

On the other hand for tags, when they're supported (like in a flow), we enforce that the matched tags are part of the API matched tags, to prevent interpreting as a tag a string that looks like a tag but that would be in a code block or equivalent.